### PR TITLE
Add Ibis (federated wiki)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ These products rule the fediverse.
 - [Synapse](https://github.com/matrix-org/synapse/) - Synapse is an open-source Matrix homeserver written in python and twisted
 - [Dendrite](https://github.com/matrix-org/dendrite/) - Dendrite is a open-source second-generation Matrix homeserver written in Go!
 - [Conduit](https://conduit.rs/) - Conduit is a simple, fast and reliable chat server powered by matrix, written in rust.
+- [Ibis](https://ibis.wiki/) - Ibis is a federated encyclopedia written in Rust. Users can read and edit articles across instances.
 ## Protocols
 
 The fediverse is made up of a bunch of protocols. Below are the most used ones.


### PR DESCRIPTION
Ibis is a federated encyclopedia written in Rust. Users can read and edit articles across instances.

https://github.com/Nutomic/ibis

https://ibis.wiki/